### PR TITLE
calculate diameter correct

### DIFF
--- a/src/RadialProgressBar.vue
+++ b/src/RadialProgressBar.vue
@@ -142,7 +142,7 @@ export default {
     },
 
     innerCircleDiameter () {
-      return this.diameter - (this.strokeWidth * 2)
+      return this.diameter - this.strokeWidth
     },
 
     innerCircleRadius () {


### PR DESCRIPTION
since the stroke-width grows from the middle of the the path the diameter should  be calculated different. otherwise the view box of the svg is too small.